### PR TITLE
fix: Extend timeout option to dataform compile command

### DIFF
--- a/src/parser/dataform-compiler.ts
+++ b/src/parser/dataform-compiler.ts
@@ -49,7 +49,7 @@ export class DataformCompiler {
     try {
       console.log('Using Dataform CLI to compile project...');
       
-      const { stdout } = await execAsync('dataform compile --timeout 10m --json', {
+      const { stdout } = await execAsync('dataform compile --timeout=10m --json', {
         cwd: projectPath,
         maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large projects
       });

--- a/src/parser/dataform-compiler.ts
+++ b/src/parser/dataform-compiler.ts
@@ -49,7 +49,7 @@ export class DataformCompiler {
     try {
       console.log('Using Dataform CLI to compile project...');
       
-      const { stdout } = await execAsync('dataform compile --json', {
+      const { stdout } = await execAsync('dataform compile --timeout 10m --json', {
         cwd: projectPath,
         maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large projects
       });


### PR DESCRIPTION
extend compile timeout for large projects

fix for https://github.com/jnakagawa/dataform_docs/issues/9